### PR TITLE
Added jacoco.exec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ dist/
 nbdist/
 nbactions.xml
 nb-configuration.xml
+jacoco.exec


### PR DESCRIPTION
I added jacoco.exec to .gitignore under the developer section. I believe that was all this user story required. 
Tests:
After building the program with ant and running git status, the jacoco.exec file no longer appeared. 
